### PR TITLE
Fix Rotation in East/West Direction

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,9 +2,9 @@
 
 dependencies {
     api 'net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev'
-    api 'com.github.GTNewHorizons:OpenComputers:1.10.11-GTNH:dev'
+    api 'com.github.GTNewHorizons:OpenComputers:1.12.16-GTNH:dev'
     compileOnly 'curse.maven:cofh-core-69162:2388751'
     compileOnly('curse.maven:mystcraft-224599:2417044') {transitive = false}
     compileOnly('curse.maven:computercraft-67504:2269339') {transitive = false}
-    api("com.github.GTNewHorizons:GTNHLib:0.2.11:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.30:dev")
 }

--- a/src/main/java/gcewing/sg/blocks/orientation/Orient4WaysByState.java
+++ b/src/main/java/gcewing/sg/blocks/orientation/Orient4WaysByState.java
@@ -55,13 +55,13 @@ public class Orient4WaysByState implements IOrientationHandler {
             case NORTH:
                 i = 0;
                 break;
-            case WEST:
+            case EAST:
                 i = 1;
                 break;
             case SOUTH:
                 i = 2;
                 break;
-            case EAST:
+            case WEST:
                 i = 3;
                 break;
             default:


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19664
Previously, when you placed the Base Block in E/W Direction, it would be flipped by 180 degrees. If placed in N/S direction, it was placed facing you. This fixes it, aswell as the stargate itself when fully formed because of this.
Tested in Full pack and now places correctly facing towards me.
before (Block is placed from where im standing in the first picture):
<img width="480" height="353" alt="image" src="https://github.com/user-attachments/assets/5e0bce1f-bb9d-434b-a811-049fdd770056" />
<img width="696" height="532" alt="image" src="https://github.com/user-attachments/assets/ceb8c409-1a07-4273-b27b-85e37f6b61e5" />
<img width="787" height="730" alt="image" src="https://github.com/user-attachments/assets/5d8dc969-fffc-4ab1-8af5-937dcbde8c88" />
<img width="667" height="597" alt="image" src="https://github.com/user-attachments/assets/92ef70f2-80b0-4c57-88fa-f07b8e649d4e" />
After:
<img width="446" height="489" alt="image" src="https://github.com/user-attachments/assets/4921f4b0-25cb-45eb-a4f8-1746ad902061" />
<img width="638" height="663" alt="image" src="https://github.com/user-attachments/assets/ec365251-ab80-48aa-8e1e-8b4826711c57" />


