### PR TITLE
Fix for ring not fully forming sometimes

### DIFF
--- a/src/main/java/gcewing/sg/blocks/SGRingBlock.java
+++ b/src/main/java/gcewing/sg/blocks/SGRingBlock.java
@@ -8,7 +8,6 @@ package gcewing.sg.blocks;
 
 import static gcewing.sg.utils.BaseBlockUtils.getWorldBlock;
 import static gcewing.sg.utils.BaseBlockUtils.getWorldBlockState;
-import static gcewing.sg.utils.BaseBlockUtils.markWorldBlockForUpdate;
 
 import java.util.List;
 
@@ -155,8 +154,7 @@ public class SGRingBlock extends SGBlock<SGRingTE> {
         SGRingTE te = getRingTE(world, pos);
         te.isMerged = true;
         te.basePos = basePos;
-        // te.onInventoryChanged();
-        markWorldBlockForUpdate(world, pos);
+        te.markBlockChanged();
     }
 
     public void unmergeFrom(World world, Vector3i pos, Vector3i basePos) {


### PR DESCRIPTION
When finally reaching Stargate in GTNH me and my buddy ceremoniously placed the blocks to set up the first gate!

Just to see that one side of the blocks did not form properly 😫 
I felt a bit disappointed at having spent ~1450 hours to get to a multiblock that was buggy..
<img width="1728" height="1056" alt="2026-03-20_21 51 42" src="https://github.com/user-attachments/assets/95e03382-9578-41dc-af3e-e3db1d6fd18e" />

Fortunately logging out and in again fixes it but it would be nice if it worked from the get-go.

I poked around and saw that the blocks that did not form were actually in a different chunk. Turns out `SGRingBlock.mergeWith()` uses `markWorldBlockForUpdate()` which only calls `world.markBlockForUpdate()`. This skips `markDirty()` on the tile entity, so the chunk may not send the updated `isMerged` state to the client side for ring blocks in a neighboring chunk. Instead if we use `te.markBlockChanged()`, it calls both `markDirty()` and `markBlockForUpdate()` with `updateChunk=true`. This is also consistent with how unmergeFrom() already works.

Tested in our world and the ring seems to always form across the chunk boundary now! 🥳 